### PR TITLE
Add README and artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Hackintosh and Beyond Script
+
+This repository contains a collection of automation scripts that download and
+build a wide range of kext projects used in the Hackintosh community.
+
+The main script clones the open-source repositories, builds them with Xcode and
+collects the resulting kexts in a single output directory.
+
+<img src="images/hackintosh-script.svg" width="300" alt="Hackintosh and Beyond" />
+
+## Usage
+
+The main executable script is `Hackintosh-and-beyond_script`. Run it from a
+macOS environment with Xcode installed:
+
+```bash
+chmod +x Hackintosh-and-beyond_script
+./Hackintosh-and-beyond_script
+```
+
+The script will clone the necessary repositories into `~/Desktop/KextsCodiFonteRelease`,
+build them and copy the built kexts to `~/Desktop/Release/package/Kexts`.
+
+## Contents
+
+- `Hackintosh And Beyond Script.app` &mdash; a packaged macOS application
+  containing the same script for convenience.
+- `Hackintosh-and-beyond_script` &mdash; the bash script that performs all
+  cloning and build steps.
+- `images/` &mdash; artwork used in this repository.
+
+Feel free to customize and adapt the script for your own build workflow!

--- a/images/hackintosh-script.svg
+++ b/images/hackintosh-script.svg
@@ -1,0 +1,9 @@
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="10" y="10" width="180" height="140" rx="10" ry="10" fill="#2d2d2d"/>
+  <text x="100" y="40" font-size="16" fill="#ffffff" text-anchor="middle">Hackintosh</text>
+  <text x="100" y="60" font-size="16" fill="#ffffff" text-anchor="middle">and Beyond</text>
+  <rect x="30" y="70" width="140" height="60" fill="#1a1a1a"/>
+  <text x="100" y="100" font-size="14" fill="#00ff00" text-anchor="middle">$ ./build_kexts.sh</text>
+  <rect x="80" y="150" width="40" height="30" rx="5" ry="5" fill="#3c6eaf"/>
+  <text x="100" y="170" font-size="12" fill="#ffffff" text-anchor="middle">Run</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a simple decorative SVG with a terminal theme
- document repository usage in a new README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684cdec61b3c83288aa3936eba4774b0

## Summary by Sourcery

Add a project README with description, usage instructions, and structure overview, and include a decorative terminal-themed SVG artwork

Enhancements:
- Include terminal-themed SVG artwork

Documentation:
- Add README documenting project purpose, usage, and contents

Chores:
- Add images directory to host artwork assets